### PR TITLE
Moved image processing from advanced-reboot.yml to separate file

### DIFF
--- a/ansible/roles/test/tasks/advanced-reboot.yml
+++ b/ansible/roles/test/tasks/advanced-reboot.yml
@@ -113,49 +113,8 @@
         stay_in_target_image:     "{{ stay_in_target_image     | default('false') | bool }}"
         cleanup_old_sonic_images: "{{ cleanup_old_sonic_images | default('false') | bool }}"
 
-    - block:
-
-        - name: Save image version
-          shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
-          register: current_sonic_image
-          become: true
-          when: not stay_in_target_image
-
-        - name: Generate temp file name on target device
-          shell: mktemp
-          register: tempfile
-
-        - set_fact:
-            new_image_location: '{{ tempfile.stdout }}'
-
-        - debug: msg='Setting image file name to {{ new_image_location }}'
-
-        - name: Download SONiC image.
-          local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
-
-        - name: Upload SONiC image to device.
-          copy:
-            src: "{{ new_image_location }}"
-            dest: "{{ new_image_location }}"
-
-        - name: Cleanup sonic images that is not current and/or next
-          shell: sonic_installer cleanup -y
-          become: true
-          when: cleanup_old_sonic_images
-
-        - name: 'Setup restoring initial image {{ current_sonic_image }}'
-          shell: /bin/true
-          connection: local
-          notify:
-          - restore current image
-          - reboot sonic
-          when: not stay_in_target_image
-
-        - name: Installing new SONiC image
-          shell: sonic_installer install -y {{ new_image_location }}
-          become: true
-
-      when: new_sonic_image | default('') | length > 0
+    - include: advanced_reboot/reboot-image-handle.yml
+      when: new_sonic_image is defined
 
     - include: ptf_runner.yml
       vars:

--- a/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
+++ b/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
@@ -1,0 +1,49 @@
+- block:
+    - fail: msg="Please set new_sonic_image variable"
+      when: new_sonic_image is not defined
+
+    - fail: msg="Please set cleanup_old_sonic_images variable"
+      when: cleanup_old_sonic_images is not defined
+
+    - fail: msg="Please set stay_in_target_image variable"
+      when: stay_in_target_image is not defined
+
+    - name: Save image version
+      shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
+      register: current_sonic_image
+      become: true
+      when: not stay_in_target_image
+
+    - name: Generate temp file name on target device
+      shell: mktemp
+      register: tempfile
+
+    - set_fact:
+        new_image_location: '{{ tempfile.stdout }}'
+
+    - debug: msg='Setting image file name to {{ new_image_location }}'
+
+    - name: Download SONiC image.
+      local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
+
+    - name: Upload SONiC image to device.
+      copy:
+        src: "{{ new_image_location }}"
+        dest: "{{ new_image_location }}"
+
+    - name: Cleanup sonic images that is not current and/or next
+      shell: sonic_installer cleanup -y
+      become: true
+      when: cleanup_old_sonic_images
+
+    - name: 'Setup restoring initial image {{ current_sonic_image }}'
+      shell: /bin/true
+      connection: local
+      notify:
+      - restore current image
+      - reboot sonic
+      when: not stay_in_target_image
+
+    - name: Installing new SONiC image
+      shell: sonic_installer install -y {{ new_image_location }}
+      become: true

--- a/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
+++ b/ansible/roles/test/tasks/advanced_reboot/reboot-image-handle.yml
@@ -1,0 +1,41 @@
+- block:
+
+    - name: Save image version
+      shell: 'sonic_installer list | grep Current | cut -f2 -d " "'
+      register: current_sonic_image
+      become: true
+      when: not stay_in_target_image
+
+    - name: Generate temp file name on target device
+      shell: mktemp
+      register: tempfile
+
+    - set_fact:
+        new_image_location: '{{ tempfile.stdout }}'
+
+    - debug: msg='Setting image file name to {{ new_image_location }}'
+
+    - name: Download SONiC image.
+      local_action: get_url url={{ new_sonic_image }} dest={{ new_image_location }}
+
+    - name: Upload SONiC image to device.
+      copy:
+        src: "{{ new_image_location }}"
+        dest: "{{ new_image_location }}"
+
+    - name: Cleanup sonic images that is not current and/or next
+      shell: sonic_installer cleanup -y
+      become: true
+      when: cleanup_old_sonic_images
+
+    - name: 'Setup restoring initial image {{ current_sonic_image }}'
+      shell: /bin/true
+      connection: local
+      notify:
+      - restore current image
+      - reboot sonic
+      when: not stay_in_target_image
+
+    - name: Installing new SONiC image
+      shell: sonic_installer install -y {{ new_image_location }}
+      become: true


### PR DESCRIPTION
…ot-image-handle.yml

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Moved ansible block which handles image to separate file. It fixes issue with nested blocks in older ansible versions.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?

#### How did you verify/test it?
Tested on Mellanox setup by running the following test case:
fast-reboot

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
