### PR TITLE
Added New test case to verify MAC addr is correct after SONiC to SONi…

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -27,7 +27,7 @@ Where:
 ---
 ### **Run test by test case tag `(DEPRECATING)`**
 
-When Ansible running playbooks by tag, it first include all tasks(all test cases) within test role shich not relate to specific tag. It's very slow along with adding more test cases and it occupied too much resource other than just run one test case using specific tag. It does not scale. 
+When Ansible running playbooks by tag, it first include all tasks(all test cases) within test role which not relate to specific tag. It's very slow along with adding more test cases and it occupied too much resource other than just run one test case using specific tag. It does not scale. 
 
 We newly added a run test case by test name option(see above setion). Running test by tag option won’t be actively maintained going forward, but will backward compatible for all already working test cases, and eventually will be phaseout. There still going to be more improvement after the initial check in. 
 
@@ -171,3 +171,11 @@ ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} -e "testbed_name
 ### CRM test
 ```
 ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} --become --tags crm
+```
+
+##### MAC read test
+```
+ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} -e testbed_name={TESTBED_NAME} -e testbed_type={TESTBED_TYPE} -e testcase_name=read_mac -e iterations={ITERATIONS} -e image1={IMAGE1} -e image2={IMAGE2}
+```
+- Replace {ITERATIONS} with the integer number of image flipping iterations.
+- Replace {IMAGE1} and {IMAGE2} with URLs to the specific SONiC binary images.

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
@@ -4,15 +4,43 @@
 
 - debug: msg="starting loganalyzer analysis phase"
 
+- set_fact:
+    loganalyzer_location: "{{ 'roles/test/files/tools/loganalyzer' }}"
+
+- set_fact:
+    match_file: loganalyzer_common_match.txt
+  when: match_file is not defined
+
+- set_fact:
+    ignore_file: loganalyzer_common_ignore.txt
+  when: ignore_file is not defined
+
+- set_fact:
+    expect_file: "loganalyzer_common_expect.txt"
+  when: expect_file is not defined
+
+- set_fact:
+    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+  when: testname_unique is not defined
+
+- set_fact:
+    test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
+  when: test_out_dir is not defined
+
 - name: Init variables
   set_fact:
-    match_file_option: "-m {{ match_file }}"
+    match_file_option: "-m "
     ignore_file_option: "-i {{ ignore_file }}"
     expect_file_option: "-e {{ expect_file }}"
 
+- name: Add common match file
+  set_fact:
+      match_file_option: "{{ match_file_option }}{{ match_file }},"
+  when: skip_common_match is not defined
+
 - name: Add test specific match file
   set_fact:
-      match_file_option: "{{ match_file_option }},{{ test_match_file }} "
+      match_file_option: "{{ match_file_option }}{{ test_match_file }}"
   when: test_match_file is defined
 
 - name: Add test specific ignore file
@@ -28,6 +56,40 @@
 - name: Set temporary file location for accumulated syslog
   set_fact:
       tmp_log_file: '/tmp/syslog'
+
+#----------------------------------------------------------------------------------
+# Copy all loganalyzer related file to DUT, and invoke loganalyzer with init phase
+#----------------------------------------------------------------------------------
+
+- name: Copy loganalyzer common match and ignore files to switch
+  copy: src="{{ loganalyzer_location }}/{{ item }}"  dest="{{ run_dir }}/{{ item }}"
+  with_items:
+        - "{{ match_file }}"
+        - "{{ ignore_file }}"
+        - "{{ expect_file }}"
+
+- name: Copy test specific file match-files to switch
+  copy: src="{{ tests_location }}/{{ testname }}/{{ test_match_file }}"  dest="{{ run_dir }}/{{ test_match_file }}"
+  when: test_match_file is defined
+
+- name: Copy test specific ignore-files to switch
+  copy: src="{{ tests_location }}/{{ testname }}/{{ test_ignore_file }}"  dest="{{ run_dir }}/{{ test_ignore_file }}"
+  when: test_ignore_file is defined
+
+- name: Copy test specific expect-files to switch
+  copy: src="{{ tests_location }}/{{ testname }}/{{ test_expect_file }}"  dest="{{ run_dir }}/{{ test_expect_file }}"
+  when: test_expect_file is defined
+
+- name: Copy loganalyzer.py to run directory
+  copy: src="{{ loganalyzer_location }}/loganalyzer.py" dest="{{ run_dir }}"
+
+# Create directory to hold results for different runs of loganalyzer
+- name: create output directory
+  file: path="{{ out_dir }}" state=directory
+
+# Create directory where loganalyzer will write output files for current run.
+- name: create output directory for current test run
+  file: path="{{ test_out_dir }}" state=directory
 
 - block:
     - name: Disable logrotate cron task

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_init.yml
@@ -1,59 +1,15 @@
 #----------------------------------------------------------------------------------
-# Copy all loganalyzer related file to DUT, and invoke loganalyzer with init phase
+# Invoke loganalyzer with init phase
 #----------------------------------------------------------------------------------
-
 - set_fact:
     loganalyzer_location: "{{ 'roles/test/files/tools/loganalyzer' }}"
-
-- set_fact:
-    match_file: loganalyzer_common_match.txt
-  when: match_file is not defined
-
-- set_fact:
-    ignore_file: loganalyzer_common_ignore.txt
-  when: ignore_file is not defined
-
-- set_fact:
-    expect_file: "loganalyzer_common_expect.txt"
-  when: expect_file is not defined
-
-- set_fact:
-    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
-  when: testname_unique is not defined
-
-- set_fact:
-    test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
-  when: test_out_dir is not defined
-
-- name: Copy loganalyzer common match and ignore files to switch
-  copy: src="{{ loganalyzer_location }}/{{ item }}"  dest="{{ run_dir }}/{{ item }}"
-  with_items:
-        - "{{ match_file }}"
-        - "{{ ignore_file }}"
-        - "{{ expect_file }}"
-
-- name: Copy test specific file match-files to switch
-  copy: src="{{ tests_location }}/{{ testname }}/{{ test_match_file }}"  dest="{{ run_dir }}/{{ test_match_file }}"
-  when: test_match_file is defined
-
-- name: Copy test specific ignore-files to switch
-  copy: src="{{ tests_location }}/{{ testname }}/{{ test_ignore_file }}"  dest="{{ run_dir }}/{{ test_ignore_file }}"
-  when: test_ignore_file is defined
-
-- name: Copy test specific expect-files to switch
-  copy: src="{{ tests_location }}/{{ testname }}/{{ test_expect_file }}"  dest="{{ run_dir }}/{{ test_expect_file }}"
-  when: test_expect_file is defined
 
 - name: Copy loganalyzer.py to run directory
   copy: src="{{ loganalyzer_location }}/loganalyzer.py" dest="{{ run_dir }}"
 
-# Create directory to hold results for different runs of loganalyzer
-- name: create output directory
-  file: path="{{ out_dir }}" state=directory
-
-# Create directory where loganalyzer will write output files for current run.
-- name: create output directory for current test run
-  file: path="{{ test_out_dir }}" state=directory
+- set_fact:
+    testname_unique: "{{ testname }}.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}"
+  when: testname_unique is not defined
 
 - debug: msg="starting loganalyzer_init.py"
 - debug: msg="python {{ run_dir }}/loganalyzer.py --action init --run_id {{ testname_unique }}"

--- a/ansible/roles/test/tasks/read_mac/check_interfaces_and_mtu.yml
+++ b/ansible/roles/test/tasks/read_mac/check_interfaces_and_mtu.yml
@@ -1,0 +1,22 @@
+- block:
+  # During 1 minute verify that interfaces became UP
+  - name: Wait until interfaces bring up
+    interface_facts: up_ports={{minigraph_ports}}
+    register: out
+    until: out.ansible_facts.ansible_interface_link_down_ports | length == 0
+    retries: 6
+    delay: 10
+  # Retrive interface facts from device
+  - interface_facts: up_ports={{minigraph_ports}}
+  # Ignore errors to display fail and continue test
+  - fail: msg="Found link down ports {{ansible_interface_link_down_ports}} "
+    when: ansible_interface_link_down_ports | length > 0
+    ignore_errors: True
+  # Ignore errors to display fail and continue test
+  - name: Verify that Ethernet and PortChannels MTU == 9100
+    assert:
+      that:
+        - "{{ ansible_interface_facts[item][\"mtu\"] }} == 9100"
+    when: ansible_interface_facts[item]["active"] == true and (item | search("Ethernet") or item | search("PortChannel"))
+    with_items: "{{ ansible_interface_facts.keys() }}"
+    ignore_errors: True

--- a/ansible/roles/test/tasks/read_mac/loganalyzer_analyze_mac.yml
+++ b/ansible/roles/test/tasks/read_mac/loganalyzer_analyze_mac.yml
@@ -1,0 +1,20 @@
+- block:
+  # Loganalyzer analyze
+  - name: Use loganalyzer to check for the error messages - {{ testname }}.
+    include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+
+  - name: Read loganalyzer summary file.
+    shell: cat "{{ test_out_dir }}/{{ summary_file }}"
+    register: log_summary
+
+  - name: Print loganalyzer summary file.
+    debug:
+      var: log_summary.stdout_lines
+
+  - name: Get the total number of error messages.
+    shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
+    register: errors_found
+
+  - name: Check the number of error messages (positive tests only).
+    fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }}."
+    when: errors_expected == false and errors_found.stdout != "0"

--- a/ansible/roles/test/tasks/read_mac/read_mac_meta_match_messages.txt
+++ b/ansible/roles/test/tasks/read_mac/read_mac_meta_match_messages.txt
@@ -1,0 +1,1 @@
+s, "Runtime error: can't parse mac address 'None'"

--- a/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
+++ b/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
@@ -1,0 +1,100 @@
+- block:
+    - set_fact:
+        current_image: "{{ image1 }}"
+      when: "{{ item|int % 2 == 0 }}"
+
+    - set_fact:
+        current_image: "{{ image2 }}"
+      when: "{{ item|int % 2 != 0 }}"
+
+    - set_fact:
+        image_to_remove: ""
+    - set_fact:
+        testname_unique: "{{ testname }}.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
+    - set_fact:
+        # Set custom match instead of default match
+        test_match_file: read_mac_meta_match_messages.txt
+        summary_file: summary.loganalysis.{{ testname_unique }}.log
+        result_file: result.loganalysis.{{ testname_unique }}.log
+        errors_expected: false
+        skip_common_match: true
+
+    - debug: msg="Iteration {{ item }}. Selected current image {{ current_image }}"
+
+    # Copy image to device
+    - set_fact: timestamp="{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
+
+    - set_fact: filename="/tmp/update_image_{{ timestamp }}"
+    - debug: var=filename
+
+    - name: Download SONiC image.
+      local_action: get_url url={{ current_image }} dest="{{ filename }}"
+
+    - name: Upload SONiC image to device.
+      copy:
+        src: "{{ filename }}"
+        dest: "/tmp/sonic-mellanox.bin"
+
+    # Init loganalyzer
+    - name: Initialize loganalizer. Put start marker to log file.
+      include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+
+    - name: Installing new SONiC image
+      shell: sonic_installer install -y /tmp/sonic-mellanox.bin
+      become: true
+
+    - name: Remove temporary image
+      become: true
+      shell: rm -rf /tmp/sonic-mellanox.bin
+
+    - name: reboot
+      include: roles/test/tasks/common_tasks/reboot_sonic.yml
+
+    - name: Verify that MAC address fits template XX:XX:XX:XX:XX:XX
+      shell: redis-cli -n 4 hget "DEVICE_METADATA|localhost" mac| grep -io '[0-9a-fA-F:]\{17\}'
+      register: mac_value
+      failed_when: mac_value.rc != 0
+
+    - name: "Get image facts"
+      image_facts:
+
+    - set_fact:
+        image_to_remove: "{{ ansible_image_facts['available'][0] }}"
+      when: "{{ ansible_image_facts['current'] != ansible_image_facts['available'][0] }}"
+
+    - set_fact:
+        image_to_remove: "{{ ansible_image_facts['available'][1] }}"
+      when:
+        - "{{ ansible_image_facts['available']|length == 2 }}"
+        - "{{ ansible_image_facts['current'] != ansible_image_facts['available'][1] }}"
+
+    - debug: msg="Current image {{ ansible_image_facts['current'] }}"
+    - debug: msg="Going to remove image {{ image_to_remove }}"
+
+    - name: Remove available image
+      shell: sonic_installer remove -y {{ image_to_remove }}
+      become: true
+      register: remove_res
+      failed_when: remove_res.rc != 0
+      when: image_to_remove != ""
+
+  # Loganalyzer analyze
+  always:
+    - name: Use loganalyzer to check for the error messages {{ testname }} iteration {{ item }}.
+      include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+
+    - name: Read loganalyzer summary file.
+      shell: cat "{{ test_out_dir }}/{{ summary_file }}"
+      register: log_summary
+
+    - name: Print loganalyzer summary file.
+      debug:
+        var: log_summary.stdout_lines
+
+    - name: Get the total number of error messages.
+      shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
+      register: errors_found
+
+    - name: Check the number of error messages (positive tests only).
+      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} / iteration {{ item }}."
+      when: errors_expected == false and errors_found.stdout != "0"

--- a/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
+++ b/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
@@ -51,8 +51,11 @@
       become: true
       shell: rm -rf /tmp/sonic-mellanox.bin
 
+    # Reboot device and wait 300 seconds for device to come back
     - name: reboot
       include: roles/test/tasks/common_tasks/reboot_sonic.yml
+      vars:
+        timeout: 300
 
     # Load minigraph
     - name: Execute cli "config load_minigraph -y" to apply new minigraph

--- a/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
+++ b/ansible/roles/test/tasks/read_mac/read_mac_metadata_loop.yml
@@ -1,23 +1,25 @@
 - block:
     - set_fact:
         current_image: "{{ image1 }}"
-      when: "{{ item|int % 2 == 0 }}"
-
-    - set_fact:
-        current_image: "{{ image2 }}"
       when: "{{ item|int % 2 != 0 }}"
 
     - set_fact:
-        image_to_remove: ""
+        current_image: "{{ image2 }}"
+      when: "{{ item|int % 2 == 0 }}"
+
     - set_fact:
-        testname_unique: "{{ testname }}.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
+        temp_minigraph: "{{ minigraph1 }}"
+      when: (current_image is search("{{ image1 }}")) and (minigraph1 is defined)
+
     - set_fact:
-        # Set custom match instead of default match
-        test_match_file: read_mac_meta_match_messages.txt
-        summary_file: summary.loganalysis.{{ testname_unique }}.log
-        result_file: result.loganalysis.{{ testname_unique }}.log
-        errors_expected: false
-        skip_common_match: true
+        temp_minigraph: "{{ minigraph2 }}"
+      when: (current_image is search("{{ image2 }}")) and (minigraph2 is defined)
+
+    - name: Copy specified minigraph to the /etc/sonic folder
+      copy:
+        src: "{{ temp_minigraph }}"
+        dest: "/etc/sonic/minigraph.xml"
+      when: temp_minigraph != ""
 
     - debug: msg="Iteration {{ item }}. Selected current image {{ current_image }}"
 
@@ -29,6 +31,8 @@
 
     - name: Download SONiC image.
       local_action: get_url url={{ current_image }} dest="{{ filename }}"
+
+    - set_fact: current_image=""
 
     - name: Upload SONiC image to device.
       copy:
@@ -50,51 +54,28 @@
     - name: reboot
       include: roles/test/tasks/common_tasks/reboot_sonic.yml
 
+    # Load minigraph
+    - name: Execute cli "config load_minigraph -y" to apply new minigraph
+      become: true
+      shell: config load_minigraph -y
+      when: temp_minigraph != ""
+
+    - set_fact: temp_minigraph=""
+
     - name: Verify that MAC address fits template XX:XX:XX:XX:XX:XX
       shell: redis-cli -n 4 hget "DEVICE_METADATA|localhost" mac| grep -io '[0-9a-fA-F:]\{17\}'
       register: mac_value
       failed_when: mac_value.rc != 0
 
-    - name: "Get image facts"
-      image_facts:
-
-    - set_fact:
-        image_to_remove: "{{ ansible_image_facts['available'][0] }}"
-      when: "{{ ansible_image_facts['current'] != ansible_image_facts['available'][0] }}"
-
-    - set_fact:
-        image_to_remove: "{{ ansible_image_facts['available'][1] }}"
-      when:
-        - "{{ ansible_image_facts['available']|length == 2 }}"
-        - "{{ ansible_image_facts['current'] != ansible_image_facts['available'][1] }}"
-
-    - debug: msg="Current image {{ ansible_image_facts['current'] }}"
-    - debug: msg="Going to remove image {{ image_to_remove }}"
-
-    - name: Remove available image
-      shell: sonic_installer remove -y {{ image_to_remove }}
+    - name: Remove old (not current) sonic image
+      reduce_and_add_sonic_images:
       become: true
-      register: remove_res
-      failed_when: remove_res.rc != 0
-      when: image_to_remove != ""
+      args:
+        disk_used_pcent: 1
 
-  # Loganalyzer analyze
-  always:
-    - name: Use loganalyzer to check for the error messages {{ testname }} iteration {{ item }}.
-      include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+    - name: Verify interfaces are UP and MTU == 9100
+      include: roles/test/tasks/read_mac/check_interfaces_and_mtu.yml
 
-    - name: Read loganalyzer summary file.
-      shell: cat "{{ test_out_dir }}/{{ summary_file }}"
-      register: log_summary
-
-    - name: Print loganalyzer summary file.
-      debug:
-        var: log_summary.stdout_lines
-
-    - name: Get the total number of error messages.
-      shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
-      register: errors_found
-
-    - name: Check the number of error messages (positive tests only).
-      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} / iteration {{ item }}."
-      when: errors_expected == false and errors_found.stdout != "0"
+    # Run lognalyzer
+    - name: Run loganalyzer
+      include: roles/test/tasks/read_mac/loganalyzer_analyze_mac.yml

--- a/ansible/roles/test/tasks/read_mac_metadata.yml
+++ b/ansible/roles/test/tasks/read_mac_metadata.yml
@@ -1,0 +1,24 @@
+# Input Parameters:
+# -e image1=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
+# -e image2=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
+# -e iterations=INT_NUMBER
+
+- block:
+  - fail: msg="Please speify URL to the image1"
+    when: image1 is not defined
+
+  - fail: msg="Please speify URL to the image2"
+    when: image2 is not defined
+
+  - fail: msg="Please speify 'iterations' variable"
+    when: iterations is not defined
+
+  - set_fact:
+      out_dir: /tmp
+      run_dir: /tmp
+      testname: read_mac
+      tests_location: roles/test/tasks
+
+  - name: Verify MAC in image reinstall loop
+    include: roles/test/tasks/read_mac/read_mac_metadata_loop.yml
+    with_sequence: count={{ iterations }}

--- a/ansible/roles/test/tasks/read_mac_metadata.yml
+++ b/ansible/roles/test/tasks/read_mac_metadata.yml
@@ -2,22 +2,51 @@
 # -e image1=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
 # -e image2=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
 # -e iterations=INT_NUMBER
+# Optional:
+# -e minigraph1=/path/to/the/minigraph.xml
+# -e minigraph2=/path/to/the/minigraph.xml
 
 - block:
-  - fail: msg="Please speify URL to the image1"
+  - fail: msg="Please specify URL to the image1"
     when: image1 is not defined
 
-  - fail: msg="Please speify URL to the image2"
+  - fail: msg="Please specify URL to the image2"
     when: image2 is not defined
 
-  - fail: msg="Please speify 'iterations' variable"
+  - fail: msg="Please specify 'iterations' variable"
     when: iterations is not defined
+
+  # Prepare variables for loganalyzer
+  - set_fact:
+      testname_unique: "{{ testname }}.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
+  - set_fact:
+      # Set custom match instead of default match
+      test_match_file: read_mac_meta_match_messages.txt
+      summary_file: summary.loganalysis.{{ testname_unique }}.log
+      result_file: result.loganalysis.{{ testname_unique }}.log
+      errors_expected: false
+      skip_common_match: true
 
   - set_fact:
       out_dir: /tmp
       run_dir: /tmp
       testname: read_mac
       tests_location: roles/test/tasks
+      current_image: ""
+      temp_minigraph: ""
+
+  - name: Check minigraph exists
+    stat:
+      path: /etc/sonic/minigraph.xml
+    register: output
+
+  - set_fact: store_original_minigraph=true
+    when: output.stat.exists
+
+  # Store current minigraph for debug purpose
+  - shell: cp /etc/sonic/minigraph.xml /home/
+    become: true
+    when: (minigraph1 is defined) or (minigraph2 is defined) and (store_original_minigraph is defined)
 
   - name: Verify MAC in image reinstall loop
     include: roles/test/tasks/read_mac/read_mac_metadata_loop.yml

--- a/ansible/roles/test/tasks/read_mac_metadata.yml
+++ b/ansible/roles/test/tasks/read_mac_metadata.yml
@@ -18,6 +18,8 @@
 
   # Prepare variables for loganalyzer
   - set_fact:
+      testname: read_mac
+  - set_fact:
       testname_unique: "{{ testname }}.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
   - set_fact:
       # Set custom match instead of default match
@@ -26,11 +28,8 @@
       result_file: result.loganalysis.{{ testname_unique }}.log
       errors_expected: false
       skip_common_match: true
-
-  - set_fact:
       out_dir: /tmp
       run_dir: /tmp
-      testname: read_mac
       tests_location: roles/test/tasks
       current_image: ""
       temp_minigraph: ""

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -240,3 +240,6 @@ testcases:
       required_vars:
           testbed_type:
 
+    read_mac:
+      filename: read_mac_metadata.yml
+      topologies: [t0, t1, t1-lag]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->
Added new test case to verify MAC address is correct after SONiC-to-SONiC update.

Test case performs:
- SONiC-to-SONiC update
- Verifies that MAC address was read correctly and its value fits the MAC address template after image update

Test case steps:
- Parse parameters
_Mandatory:_
image1, image2, iterations
_Optional:_
minigraph1
minigraph2

In the loop:
- Select/flip image
- If minigraph specified for selected image - upload minigraph to the "/etc/sonic/minigraph.xml" folder
- Download selected image and copy it to the device
- Init loganalyzer
- Install copied image
- Reboot device
- If minigraph specified for selected image  perform command - "config load_minigraph -y"
- Verify MAC address fits "xx:xx:xx:xx:xx:xx" template
- Remove old (not current) image
- Verify interfaces are UP and configured MTU is 9100
- Run loganalyzer
- Analyze loganalyzer results

Test case parameters:
image1,image2 - URL to the SONIC binary image
iterations - Number of times to switch between two images and perform MAC verification
minigraph1, minigraph2 - Minigraph file which is used by "config load_minigraph -y" command

PASS/FAIL criteria:
- After install SONiC image and reboot device:
	- MAC address in CONFIG_DB must fit 6 byte template "xx:xx:xx:xx:xx:xx"
	- Error messages about "None" MAC address are absent in Syslog

Notes:
Verification of Linkdown ports and configured MTU just display errors without failing test.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] New test case

### Approach
#### How did you do it?

#### How did you verify/test it?
Tested on our local testbed.
Test case expect the following parameters:
-e image1=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
-e image2=http://IP_ADDR/SERVER_URL/IMAGE_NAME.bin
-e iterations=INT_NUMBER
Optional:
-e minigraph1=minigraph/SWITCH.TOPOLOGY.xml
-e minigraph2=minigraph/SWITCH.TOPOLOGY.xml

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
