### PR TITLE
Added interface counters verification before/after test cases.

### DIFF
--- a/ansible/roles/test/files/helpers/interface_counters.sh
+++ b/ansible/roles/test/files/helpers/interface_counters.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+IFS=$'\n'
+
+RX_BPS_INDEX=0
+NA_LEN=3
+
+SHOW_COUNTERS=`show interfaces counters`
+ERROR_MSG="The following fields contains 'N/A':"
+FAILED=false
+
+for l in $SHOW_COUNTERS
+do
+    if [[ "${l}" =~ "RX_BPS" ]] ;
+    then
+        rx_bps_index=$(echo $l | awk -v s=RX_BPS '{print index($l,s) + length("RX_BPS") - 4}')
+        tx_bps_index=$(echo $l | awk -v s=TX_BPS '{print index($l,s) + length("TX_BPS") - 4}')
+        rx_util_index=$(echo $l | awk -v s=RX_UTIL '{print index($l,s) + length("RX_UTIL") - 4}')
+        tx_util_index=$(echo $l | awk -v s=TX_UTIL '{print index($l,s) + length("TX_UTIL") - 4}')
+    fi
+
+    if [[ "${l:$rx_bps_index:$NA_LEN}" = "N/A" ]] && [[ "$ERROR_MSG" != *"RX_BPS"* ]] ;
+    then
+        FAILED=true
+        ERROR_MSG="$ERROR_MSG RX_BPS"
+    fi
+    if [[ ${l:$tx_bps_index:$NA_LEN} == "N/A" ]] && [[ "$ERROR_MSG" != *"TX_BPS"* ]] ;
+    then
+        FAILED=true
+        ERROR_MSG="$ERROR_MSG TX_BPS"
+    fi
+    if [[ ${l:$rx_util_index:$NA_LEN} == "N/A" ]] && [[ "$ERROR_MSG" != *"RX_UTIL"* ]] ;
+    then
+        FAILED=true
+        ERROR_MSG="$ERROR_MSG RX_UTIL"
+    fi
+    if [[ ${l:$tx_util_index:$NA_LEN} == "N/A" ]] && [[ "$ERROR_MSG" != *"TX_UTIL"* ]] ;
+    then
+        FAILED=true
+        ERROR_MSG="$ERROR_MSG TX_UTIL"
+    fi
+done
+
+if [[ $FAILED = true ]] ;
+then
+    echo $ERROR_MSG
+    echo $SHOW_COUNTERS
+    exit 1
+fi
+exit 0

--- a/ansible/roles/test/tasks/interface.yml
+++ b/ansible/roles/test/tasks/interface.yml
@@ -56,3 +56,6 @@
 - name: Verify VLAN interfaces are up correctly
   assert: { that: "'{{ ansible_interface_facts[item]['active'] }}' == 'True'" }
   with_items: "{{ minigraph_vlans.keys() }}"
+
+- name: Verify interfaces counters
+  include: interface_counters.yml

--- a/ansible/roles/test/tasks/interface_counters.yml
+++ b/ansible/roles/test/tasks/interface_counters.yml
@@ -1,0 +1,18 @@
+- name: Copy interface_counters.sh to the DuT
+  become: true
+  copy:
+    src: roles/test/files/helpers/interface_counters.sh
+    dest: /tmp/interface_counters.sh
+    mode: 0755
+
+- name: Run interface_counters.sh
+  become: true
+  shell: /tmp/interface_counters.sh
+  register: results
+  failed_when: results.rc != 0
+
+- name: Delete interface_counters.sh from the DuT
+  become: true
+  file:
+    state: absent
+    path: /tmp/interface_counters.sh


### PR DESCRIPTION
Signed-off-by: Yuriy Volynets <yuriyv@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary: Extended pre and post test sanity check to get output of "show interfaces counters" command and verify that "RX_BPS", "TX_BPS", "RX_UTIL", "TX_UTIL" rows does not contain "N/A". If any row contains "N/A", test will fail and this information will be displayed in the fail message.
Fixes # (issue)

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)

### Approach
#### How did you do it?
Added "interface_counters.sh" script which pars output of "show interfaces counters" command and verify that "RX_BPS", "TX_BPS", "RX_UTIL", "TX_UTIL" rows does not contain "N/A".

Added "interface_counters.yml" script which includes "interface_counters.sh".

Updated "interface.yml" to call "interface_counters.yml".

#### How did you verify/test it?
Tested on the local setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
